### PR TITLE
Support PureScript 0.8.5 output.

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -13,6 +13,7 @@ import System.IO
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Vector as V
+import Data.Monoid ((<>))
 
 import ProcessModule
 import ProcessRootModule


### PR DESCRIPTION
When upgrading to PS 0.8.5 from 0.8.0 `psc-bundle-fast` ceased working with an error along the lines of:

```
psc-bundle-fast: build/../Some.Module/index.js: openFile: does not exist (No such file or directory)
```

On doing some digging, I think this is because PS has changed its code generator so that modules are now required with relative paths, viz.:

``` javascript
var Some_Module = require("../Some.Module");
```

Modifying `psc-bundle-fast` to expect this appears to fix everything. I think the code should still work with older versions too due its falling back to the given string if `stripPrefix "../"` fails (returns `Nothing`) but have not tested this extensively. Thoughts?
