### PR TITLE
Upgrade to latest purs index.js output

### DIFF
--- a/src/ProcessModule.hs
+++ b/src/ProcessModule.hs
@@ -95,7 +95,7 @@ parseImportStatement l =
 
     removeRelativePath :: Text -> Text
     removeRelativePath t =
-        fromMaybe t (T.stripPrefix "../" t)
+         fromMaybe t (T.stripPrefix "../" t >>= T.stripSuffix "/index.js")
 
 formatImport :: Namespace -> (Text, Text) -> Text
 formatImport namespace (varName, modName) =
@@ -162,7 +162,7 @@ createImportSection namespace modulename ls (Just (firstIndex, numImports)) =
     next (createdLines, foundReqModules, needsForeign) line =
         case parseImportStatement line of
             Nothing -> (createdLines, foundReqModules, needsForeign)
-            Just (varName, reqModule) -> case reqModule == "./foreign" of
+            Just (varName, reqModule) -> case reqModule == "./foreign.js" of
                 True -> let newLine = formatImport namespace (varName, modulename) -- Load the `modulename` instead of trying to load "./foreign"
                     in (createdLines `V.snoc` newLine, foundReqModules, True)
                 False -> let newLine = formatImport namespace (varName, reqModule)


### PR DESCRIPTION
Latest purs output produces slightly different requires for the `index.js` and the foreign require is `foreign.js` now. I patched it on the weekend and now it's working fine.

Tested on my project with these stack extra-deps:

```
extra-deps:
- happy-1.19.9
- github: purescript/purescript
  commit: ed130c78b708ff55cf4a80b126a1bd3ba5d80eb9
- github: purescript/psc-package
  commit: 24a696131bca63513a84d0a9b691f773c7b37069
- github: chrisdone/purescript-bundle-fast
  commit: c5a75b57cd2aa442bf03edfe5a6702b4df0fc45e
```